### PR TITLE
Implement link validation in edit panel

### DIFF
--- a/src/code/index.js
+++ b/src/code/index.js
@@ -6,9 +6,7 @@ const home = document.getElementById("home");
 const info = document.getElementById("info");
 const edit = document.getElementById("edit");
 
-
 // ============== Header ==============
-
 
 infoBtn.addEventListener("click", () => {
     console.log("Info button clicked!");
@@ -51,7 +49,6 @@ showBtn.addEventListener("click", () => {
 
 // ============== Utility Functions ==============
 
-
 function getSocialLinks() {
     const socialLinks = {};
 
@@ -79,7 +76,6 @@ function getSocialLinks() {
 
 const socialLinks = getSocialLinks();
 
-
 // ============== Edit ==============
 function previewLink(button) {
     const parentElement = button.parentNode;
@@ -89,7 +85,6 @@ function previewLink(button) {
     console.log("Input value:", inputValue);
     // Rest of the code...
 }
-
 
 // ============== Random Placeholder Generation ==============
 const placeholderTexts = [
@@ -129,3 +124,34 @@ function randomTextGenerator(placeholderTexts) {
     const randomIndex = Math.floor(Math.random() * placeholderTexts.length);
     return placeholderTexts[randomIndex];
 }
+
+// ============== Link Validation ==============
+
+function validateLink(input) {
+    const linkPattern = /^(http:\/\/|https:\/\/|mailto:)[\w.-]+(?:\.[\w.-]+)+[\w\-\._~:/?#[\]@!$&'()*+,;=]+$/;
+    const isValid = linkPattern.test(input.value);
+    const messageElement = input.nextElementSibling || document.createElement("span");
+    const previewButton = input.parentNode.querySelector(".preview");
+
+    if (isValid) {
+        input.style.borderBottomColor = "green";
+        previewButton.disabled = false;
+        if (messageElement.tagName === "SPAN") {
+            messageElement.remove();
+        }
+    } else {
+        input.style.borderBottomColor = "red";
+        previewButton.disabled = true;
+        if (messageElement.tagName !== "SPAN") {
+            messageElement.textContent = "Entered link is not valid";
+            messageElement.style.color = "red";
+            messageElement.style.position = "absolute";
+            messageElement.style.bottom = "-20px";
+            input.parentNode.appendChild(messageElement);
+        }
+    }
+}
+
+document.querySelectorAll("#edit .link input[type='text']").forEach(input => {
+    input.addEventListener("input", () => validateLink(input));
+});

--- a/src/code/style.css
+++ b/src/code/style.css
@@ -16,6 +16,8 @@
     --accent-color: #eae4f7;
     --text-color: #eeeeee;
     --text-color-2: #242327;
+    --valid-input-color: green;
+    --invalid-input-color: red;
 }
 
 body {
@@ -281,7 +283,7 @@ table td {
     transform: scale(1.1);
 }
 
-/* ============== Edut Panel ============== */
+/* ============== Edit Panel ============== */
 #edit {
     gap: 0;
 }
@@ -420,6 +422,20 @@ table td {
     font-style: italic;
 }
 
+.link input[type="text"].valid {
+    border-bottom-color: var(--valid-input-color);
+}
+
+.link input[type="text"].invalid {
+    border-bottom-color: var(--invalid-input-color);
+}
+
+.invalid-message {
+    color: var(--invalid-input-color);
+    font-size: 0.8rem;
+    position: absolute;
+    bottom: -20px;
+}
 
 #save-btn-area {
     display: flex;


### PR DESCRIPTION
Related to #41

Implements a link validation feature in the edit panel to check the validity of entered links, change input border colors accordingly, and enable the preview button for valid links.

- **Validation Logic**: Adds a `validateLink` function in `src/code/index.js` that validates links against a regex pattern to check if they start with `http`, `https`, or `mailto`. This function is triggered on input change for all text inputs within the `edit` section.
- **UI Feedback**: Modifies input border color to red for invalid links and green for valid links directly within the `validateLink` function. Additionally, displays an error message under the input field if the link is invalid, using absolute positioning to avoid layout shifts.
- **Preview Button**: Enables the preview button next to the input field if the entered link is valid, ensuring users can only preview valid links.
- **Styling**: Updates `src/code/style.css` to include styles for valid and invalid input states, such as changing the input border color and styling the error message displayed for invalid links.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Param302/SocialRepo/issues/41?shareId=8c1c1974-9195-4ea0-84b7-00d9f005f271).