### PR TITLE
Hover effect (displaying social media app name)

### DIFF
--- a/src/code/index.js
+++ b/src/code/index.js
@@ -60,10 +60,12 @@ function getSocialLinks() {
             return response.json();
         })
         .then(jsonData => {
+            console.log(jsonData)
             Object.keys(jsonData).slice(1).forEach(key => {
                 socialLinks[key] = jsonData[key];
                 createSocialLink(key, jsonData[key]);
             });
+            console.log(socialLinks)
             return socialLinks;
         })
         .catch(error => {
@@ -91,8 +93,24 @@ function createImage(key) {
 const socialLinksContainer = document.getElementById("socialLinks");
 function createSocialLink(key, value) {
     const li = document.createElement("li");
+    const div = document.createElement("div")
     const img = createImage(key);
+    div.classList.add('hover-div')
+    if (key.length>8){
+        div.textContent = `${key.substr(0,8)+"..."}`
+    }else{
+        div.textContent = key
+    }
+    li.addEventListener("mouseenter",()=>{
+        img.style.display = 'none'
+        div.style.display = 'flex'
+    })
+    li.addEventListener('mouseleave',()=>{
+        img.style.display = 'block'
+        div.style.display = 'none'
+    })
     img.onload = () => {
+        li.appendChild(div)
         li.appendChild(img);
         li.addEventListener("click", () => {
             navigator.clipboard.writeText(value); // Copy the value to clipboard

--- a/src/code/index.js
+++ b/src/code/index.js
@@ -93,9 +93,11 @@ function createImage(key) {
 const socialLinksContainer = document.getElementById("socialLinks");
 function createSocialLink(key, value) {
     const li = document.createElement("li");
+    //^ New div which will contain the name of app (displayed on hover)
     const div = document.createElement("div")
     const img = createImage(key);
     div.classList.add('hover-div')
+    //^ making the string short if it overflows (based upon its length)
     if (key.length>8){
         div.textContent = `${key.substr(0,8)+"..."}`
     }else{

--- a/src/code/style.css
+++ b/src/code/style.css
@@ -183,6 +183,21 @@ p {
     width: 100%;
     height: 100%;
 }
+.hover-div{
+    /* position: absolute;
+    top: 105%; */
+    display: none;
+    justify-content: center;
+    align-items: center;
+    height: inherit;
+    width: inherit;
+    border-radius: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--accent-color);
+    background-color: transparent;
+    overflow: hidden;
+}
 
 /* ============== Info Panel ============== */
 


### PR DESCRIPTION
# Social media name visible on hover

## Description
In this PR, I have added the functionality of displaying the Social Media Platform name when the user hovers on it instead of the icon. This functionality will help improve the UX of the extension as some users might not be aware about all the social media platforms.

## Before 

https://github.com/Param302/SocialRepo/assets/142862928/a25fe0b7-88e7-468a-b097-73be25ff91a5

## After

https://github.com/Param302/SocialRepo/assets/142862928/56b2763b-6804-471d-8cef-346e06e4ae71


---
## Issue Ticket Number
Fixes #65 
Please merge. @Param302 

---
## Type of change
<!-- Please select all options that are applicable. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING](./docs/CONTRIBUTING)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Param302/SocialRepo/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation